### PR TITLE
add trackUserLocation

### DIFF
--- a/src/components/map-container/map-container-component.vue
+++ b/src/components/map-container/map-container-component.vue
@@ -38,7 +38,8 @@ import 'mapbox-gl/dist/mapbox-gl.css';
  */
 
 // ⚠️PR REVIEWERS - Make sure this is commented out before merge!
-// mapboxgl.accessToken = process.env.VUE_APP_MAPBOX_KEY as string;
+// 5/7/19 - Uncommenting to test user location in prod vs localhost on mobile
+mapboxgl.accessToken = process.env.VUE_APP_MAPBOX_KEY as string;
 
 interface GeoJsonFeature {
   type: string;
@@ -84,7 +85,18 @@ export default class MapContainerComponent extends Vue {
   private createMap() {
     if (!this.mapLoaded && mapboxgl.accessToken) {
       const map = new mapboxgl.Map(this.mapboxOptions);
+
+      // Zoom controls
       map.addControl(new mapboxgl.NavigationControl());
+      
+      // Track user's Current Location
+      map.addControl(new mapboxgl.GeolocateControl({
+        positionOptions: {
+          enableHighAccuracy: true
+        },
+        trackUserLocation: true
+      }));
+
       this.loadMarkers(map);
 
       // Assures that the map is only loaded once


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The MapboxGL library allows us to track user location.  It works successfully on Chrome for Desktop, but not on mobile Chrome or other mobile web browsers.  I suspect this is due to being served over http / localhost, since Chrome assumes that localhost is secure but Safari does not, so we're pushing up this PR to test on the Heroku deployment.

## Description
<!--- Describe your changes in detail -->
- Adds new `GeolocateControl` to track user location
- Enables the map to be displayed for testing

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/10617750/57326003-a9707380-70c8-11e9-95b7-3d4f76ce576d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
