### PR TITLE
add ability to fire google directions when clicking on venue address

### DIFF
--- a/src/views/venue-details/venue-details.vue
+++ b/src/views/venue-details/venue-details.vue
@@ -14,7 +14,7 @@
     </AlertBanner>
     <div class="venue-details">
       <div class="venue-details--title global-title">{{venue.name}}</div>
-      <div class="venue-address">
+      <div class="venue-address" v-on:click="openDirections(venue.address)">
         <img class="venue-address--image" src="../../images/location-icon.svg" alt="Location icon">
         {{venue.address}}
       </div>
@@ -51,6 +51,14 @@ export default class VenueDetails extends Vue {
   public beforeMount() {
     const Id: number = parseFloat(this.$route.params.venueId);
     this.venue = this.venueSevice.getSelectedVenue(Id);
+  }
+
+  public openDirections(destination: string) {
+    const urlEncodedDestination = encodeURIComponent(destination);
+    const fullUrlPath =
+      `https://www.google.com/maps/dir/?api=1&destination=${urlEncodedDestination}&travelmode=walking`;
+
+    window.open(fullUrlPath);
   }
 }
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a method that triggers google maps to open up and direct users to the venue of their choosing. This is done so by clicking on the address of the venue. The default params are set for the user's current location and walking as their transportation method. The following actions should fire depending on device ;

- IOS = Opens google maps native app, or web app if the app is not installed.
- Android = Opens google maps native app
- Web users = Opens google maps web app. 

## Related Issue

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
