### PR TITLE
adjusted top of scroll so its not overlaping with visited sign

### DIFF
--- a/src/components/venue-list-scroll/venue-list-scroll-component.scss
+++ b/src/components/venue-list-scroll/venue-list-scroll-component.scss
@@ -1,6 +1,6 @@
 .venue-list-scroll {
   position: absolute;
-  top: 400px;
+  top: 550px;
   bottom: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
adjusted top of venue scroll so that it no longer overlaps visited sign.


![image](https://user-images.githubusercontent.com/22819943/61667132-6c168d80-ac96-11e9-9ec8-0c7537d5e4ba.png)

