### PR TITLE
count-down toggles visibility based upon timing of user to the current event

### DIFF
--- a/src/components/countdown/countdown-component.vue
+++ b/src/components/countdown/countdown-component.vue
@@ -9,29 +9,72 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import AlertBanner from '@/components/alert-banner/alert-banner-component.vue';
+import EventService from '@/services/event-service';
+
+interface StumblEvent {
+  startTime: string;
+  endTime: string;
+}
+
+/**
+ * ACTIVE => Countdown is running and visible
+ * INACTIVE => Countdown is not visible, currently in the middle of event
+ * DISABLED => There are no other events, no need for a countdown
+ */
+enum CountdownState {
+  ACTIVE,
+  INACTIVE,
+  DISABLED,
+}
 
 @Component({
   components: {
     AlertBanner,
   },
-  props: {
-    countdownDateString: String,
-  },
 })
 export default class CountdownComponent extends Vue {
   public countdownString = '';
+  private currentEvent: StumblEvent | undefined = undefined;
+  private currentEventIndex: number = 0;
+  private countdownState: CountdownState = CountdownState.INACTIVE;
 
   public mounted() {
-    // Set the date we're counting down to
-    const countdownDate = new Date(this.$props.countdownDateString).getTime();
+    this.currentEvent = EventService.getNextEvent(this.currentEventIndex);
+    let countdownDate: number;
+
+    if (this.currentEvent !== undefined) {
+      countdownDate = new Date(this.currentEvent.startTime).getTime();
+    }
 
     // Update the count down every 1 second
     setInterval(() => {
       // Get today's date and time
       const now = new Date().getTime();
 
+      // if the event is not valid and the countdown has not been disabled, find another valid event
+      if (!this.isValidEvent(now, this.currentEvent) && this.countdownState !== CountdownState.DISABLED) {
+
+        // Check if the current event is valid, otherwise check for the next event;
+        while (!this.isValidEvent(now, this.currentEvent)) {
+          this.currentEventIndex++;
+          this.currentEvent = EventService.getNextEvent(this.currentEventIndex);
+
+          // If the event is undefined we have exhausted our events and must break out;
+          if (this.currentEvent === undefined) {
+            break;
+          }
+        }
+      } else {
+        if (this.currentEvent !== undefined) {
+          countdownDate = new Date(this.currentEvent.startTime).getTime();
+        }
+      }
+
+      // Set the state of the countdown
+      this.setCountdownState(now, this.currentEvent);
+
       // skip math if the current date is past the countdownDate
-      if (countdownDate < now) {
+      if (this.countdownState === CountdownState.INACTIVE || this.countdownState === CountdownState.DISABLED) {
         this.countdownString = '';
         return;
       }
@@ -61,7 +104,51 @@ export default class CountdownComponent extends Vue {
    * Hide the countdown timer if the event has already started.
    */
   get showCountdown(): boolean {
-    return this.countdownString !== '';
+    return this.countdownState === CountdownState.ACTIVE;
+  }
+
+  /**
+   * Check to is if event is valid.
+   * If our time is before or between the start and end time then the event is valid.
+   * If it is after the end time then the event is not valid.
+   * If the event is undefined, it is not valid.
+   */
+  private isValidEvent(currentDate: number, event?: StumblEvent): boolean {
+    if (event === undefined) {
+      return false;
+    }
+
+    const startTimeInMilli = new Date(event.startTime).getTime();
+    const endTimeInMilliseconds = new Date(event.endTime).getTime();
+
+    const isBeforeStartOfEvent = currentDate <= startTimeInMilli;
+    const isDuringEvent = (currentDate >= startTimeInMilli && currentDate <= endTimeInMilliseconds);
+
+    if (isBeforeStartOfEvent || isDuringEvent) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Set the state of the countdown based upon the current event
+   */
+  private setCountdownState(currentDate: number, event?: StumblEvent) {
+    if (event === undefined) {
+      this.countdownState = CountdownState.DISABLED;
+      return;
+    }
+
+    const startTimeInMilli = new Date(event.startTime).getTime();
+    const endTimeInMilliseconds = new Date(event.endTime).getTime();
+    const isBeforeStartOfEvent = currentDate <= startTimeInMilli;
+
+    if (isBeforeStartOfEvent) {
+      this.countdownState = CountdownState.ACTIVE;
+    } else {
+      this.countdownState = CountdownState.INACTIVE;
+    }
   }
 }
 </script>

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -1,0 +1,22 @@
+// Tuesday:   https://www.denverstartupweek.org/schedule/6066-startup-crawl-night-1
+// Thursday:  https://www.denverstartupweek.org/schedule/6067-startup-crawl-night-2
+
+const EVENTS = [
+  {startTime: 'Sep 17, 2019 16:00:00', endTime: 'Sep 17, 2019 17:00:00'},
+  {startTime: 'Sep 19, 2019 16:00:00', endTime: 'Sep 19, 2019 17:00:00'},
+];
+
+interface StumblEvent {
+  startTime: string;
+  endTime: string;
+}
+
+export default class EventService {
+  public static getNextEvent(index: number): StumblEvent | undefined {
+    if (index === null || index === undefined) {
+      index = 0;
+    }
+
+    return EVENTS[index];
+  }
+}

--- a/src/views/home/home.vue
+++ b/src/views/home/home.vue
@@ -4,7 +4,7 @@
     <div class="home">
       <Map />
       <VenueListScroll>
-        <Countdown :countdownDateString="eventStart" />
+        <Countdown />
         <AlertBanner
           class="alert-location-denied"
           :color="'green'"
@@ -35,11 +35,6 @@ import { Venue } from '../../models/venue-model';
 import router from '@/router';
 import { AlertTypeEnum } from '../../models/alert-model';
 
-// TODO: Refactor to check if current time is within the bounds of each crawl event
-// Tuesday:   https://www.denverstartupweek.org/schedule/6066-startup-crawl-night-1
-// Thursday:  https://www.denverstartupweek.org/schedule/6067-startup-crawl-night-2
-const START_DATE = 'Sep 16, 2019 16:00:00';
-
 @Component<Home>({
   components: {
     Header,
@@ -56,7 +51,6 @@ export default class Home extends Vue {
   public locationService = new LocationService();
 
   public locationPermissionActivated = false;
-  public eventStart = START_DATE;
   public locationPermissionLink = '';
   public polling: any = null; // polling interval
 


### PR DESCRIPTION
## Description
- if current time is before event, countdown will be visible.
- if current time is during event, countdown hides.
- if current time is after an event, countdown will look for a next event and begin counting down.
- if there are no more events, countdown hides.

## Related Issue

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
