### PR TITLE
Auth service, login flow with password confirmation & password reset

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -20,6 +20,7 @@ import { AlertTypeEnum } from './models/alert-model';
 import AlertBanner from '@/components/alert-banner/alert-banner-component.vue';
 import { VenuesService } from '@/services/venue-service';
 import { Venue } from '@/models/venue-model';
+import { User } from '@/models/user-model';
 
 const ALERT_TIMEOUT = 2500;
 
@@ -31,8 +32,6 @@ const ALERT_TIMEOUT = 2500;
 export default class App extends Vue {
   public venueService: VenuesService = new VenuesService();
   public allVenues: Venue[] = [];
-
-  // TODO: Set to true when authentication is completed
   public authenticated = false;
   public alertTypeColor = 'green';
   public showAlert = false;
@@ -62,6 +61,11 @@ export default class App extends Vue {
       this.showAlert = false;
       this.message = '';
     }, alertTimeout);
+  }
+
+  private handleLoginEvent() {
+    this.authenticated = true;
+    this.$router.push({ name: 'home' });
   }
 }
 </script>

--- a/src/app.vue
+++ b/src/app.vue
@@ -8,7 +8,7 @@
       <AlertBanner v-if="showAlert" :color="alertTypeColor" :icon="'clock'">
         <strong>{{message}}</strong>
       </AlertBanner>
-      <router-view @send-alert="showAlertBanner" />
+      <router-view @send-alert="showAlertBanner" :all-venues="allVenues"/>
     </div>
   </div>
 </template>
@@ -18,6 +18,8 @@ import { Component, Vue } from 'vue-property-decorator';
 import { setTimeout } from 'timers';
 import { AlertTypeEnum } from './models/alert-model';
 import AlertBanner from '@/components/alert-banner/alert-banner-component.vue';
+import { VenuesService } from '@/services/venue-service';
+import { Venue } from '@/models/venue-model';
 
 const ALERT_TIMEOUT = 2500;
 
@@ -27,11 +29,18 @@ const ALERT_TIMEOUT = 2500;
   },
 })
 export default class App extends Vue {
+  public venueService: VenuesService = new VenuesService();
+  public allVenues: Venue[] = [];
+
   // TODO: Set to true when authentication is completed
   public authenticated = false;
   public alertTypeColor = 'green';
   public showAlert = false;
   public message = '';
+
+  public async beforeMount() {
+    this.allVenues = await this.venueService.getAllVenues();
+  }
 
 /**
  * Method to dispaly the AlertBanner at the top of the AppComponent.

--- a/src/components/map-container/map-container-component.vue
+++ b/src/components/map-container/map-container-component.vue
@@ -9,7 +9,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
-
+import { Venue } from '@/models/venue-model';
 import mapboxgl, { MapboxOptions, LngLatLike, ImageSource } from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { VenuesService } from '@/services/venue-service';
@@ -28,6 +28,7 @@ export default class MapContainerComponent extends Vue {
   public mapLoaded = false;
   public markers: mapboxgl.Marker[] = [];
   public visitedVenues = this.venuesService.visitedVenues;
+  public allVenues!: Venue[];
 
   /**
    * This component leverages `Mapbox GL JS`
@@ -53,7 +54,7 @@ export default class MapContainerComponent extends Vue {
     // if the venues exist create the map
     // This is used for all page visits after app is loaded and inital call
     // to the API is finished
-    if (!!this.allVenues.length) {
+    if (this.allVenues.length > 0) {
       this.createMap();
     }
 

--- a/src/components/map-container/map-container-component.vue
+++ b/src/components/map-container/map-container-component.vue
@@ -18,7 +18,11 @@ import { GeoJsonVenue, GeoJsonFeature } from '../../models/geojson-feature';
 mapboxgl.accessToken = process.env.VUE_APP_MAPBOX_KEY as string;
 
 
-@Component({})
+@Component({
+  props: {
+    allVenues: Array,
+  },
+})
 export default class MapContainerComponent extends Vue {
   public venuesService = new VenuesService();
   public mapLoaded = false;
@@ -46,7 +50,18 @@ export default class MapContainerComponent extends Vue {
 
   // Lifecycle hook
   private mounted() {
-    this.createMap();
+    // if the venues exist create the map
+    // This is used for all page visits after app is loaded and inital call
+    // to the API is finished
+    if (!!this.allVenues.length) {
+      this.createMap();
+    }
+
+    // This will watch the prop allVenues and on change createMap()
+    // This is used on initial page load while the API is still fetching the venues
+    this.$watch('allVenues', () => {
+      this.createMap();
+    });
   }
 
   // Build the Mapbox instance and draw the map
@@ -84,7 +99,7 @@ export default class MapContainerComponent extends Vue {
   private async loadMarkers(map: mapboxgl.Map) {
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     // TODO: These are sample data points to test markers.  Replace with points from database.
-    const geojsonVenues = await this.venuesService.getAllVenuesAsGeoJSON();
+    const geojsonVenues = await this.venuesService.getAllVenuesAsGeoJSON(this.allVenues);
 
     geojsonVenues.features.forEach((venue: GeoJsonVenue, index: number) => {
       let markerLabel: any;

--- a/src/components/map/map-component.vue
+++ b/src/components/map/map-component.vue
@@ -4,7 +4,7 @@
 
 <template>
   <div class="map">
-    <MapContainer/>
+    <MapContainer :all-venues="allVenues"/>
   </div>
 </template>
 
@@ -16,6 +16,9 @@ import MapContainer from '@/components/map-container/map-container-component.vue
 @Component({
   components: {
     MapContainer,
+  },
+  props: {
+    allVenues: Array,
   },
 })
 export default class MapComponent extends Vue {}

--- a/src/components/onboarding/email/enter-email-component.scss
+++ b/src/components/onboarding/email/enter-email-component.scss
@@ -19,5 +19,17 @@
       border-bottom: 3px solid $color_button-green;
       color: green;
     }
+
+    &.first {
+      margin-bottom: 10px;
+    }
+  }
+
+  .form-error {
+    padding: 10px;
+    background-color: white;
+    border-radius: 4px;
+    font-weight: 600;
+    color: red;
   }
 }

--- a/src/components/onboarding/email/enter-email-component.vue
+++ b/src/components/onboarding/email/enter-email-component.vue
@@ -6,10 +6,13 @@
   <div class="intro--enter-email">
     <h1>Track Progress</h1>
     <p>Enter your email to track your progress and be rewarded!</p>
-    <input :class="{'valid': validEmail}" type="text" name="email" id="email" :placeholder="placeholder" v-model="entered" >
-    <div style="color: red;" v-if="entered">Testing binding: {{entered}}</div>
-    <p>This will ONLY be used to inform you if you've won</p>
+    <input :class="{'valid': validEmail}" type="text" name="email" id="email" :placeholder="placeholder" v-model="email" >
+    <input :class="{'valid': validPassword}" type="password" name="password" id="password" :placeholder="'Password'" v-model="password" >
+    <div style="color: red;" v-if="email">Testing binding: {{entered}}</div>
+    <p>Email will ONLY be used as login and to inform you if you've won</p>
     <IntroStepCounter :numberOfSteps="numberOfSteps" :step="stepNumber" />
+    <Button :title="'Sign Up'" backgroundColor="green"/>
+    <Button :title="'Log In'" backgroundColor="blue"/>
   </div>
 </template>
 
@@ -18,6 +21,7 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 
 import IntroStepCounter from '@/components/intro-step-counter/intro-step-counter-component.vue';
+import Button from '@/components/button/button-component.vue';
 
 @Component({
   props: {
@@ -26,10 +30,12 @@ import IntroStepCounter from '@/components/intro-step-counter/intro-step-counter
   },
   components: {
     IntroStepCounter,
+    Button,
   },
 })
 export default class EnterEmailComponent extends Vue {
-  public entered = '';
+  public email = '';
+  public password = '';
   public placeholder = 'ILove@DenStartupWeek.com';
 
   // API CALL
@@ -41,7 +47,11 @@ export default class EnterEmailComponent extends Vue {
     // Super simple email validation
     // Checks if there's chars before and after @,
     // and if there's chars before and after dot
-    return /^.+@.+\..+$/.test(this.entered);
+    return /^.+@.+\..+$/.test(this.email);
+  }
+
+  get validPassword() {
+    return this.password.length > 6;
   }
 }
 </script>

--- a/src/components/onboarding/email/enter-email-component.vue
+++ b/src/components/onboarding/email/enter-email-component.vue
@@ -4,15 +4,31 @@
 
 <template>
   <div class="intro--enter-email">
-    <h1>Track Progress</h1>
-    <p>Enter your email to track your progress and be rewarded!</p>
-    <input :class="{'valid': validEmail}" type="text" name="email" id="email" :placeholder="placeholder" v-model="email" >
-    <input :class="{'valid': validPassword}" type="password" name="password" id="password" :placeholder="'Password'" v-model="password" >
-    <div style="color: red;" v-if="email">Testing binding: {{entered}}</div>
-    <p>Email will ONLY be used as login and to inform you if you've won</p>
-    <IntroStepCounter :numberOfSteps="numberOfSteps" :step="stepNumber" />
-    <Button :title="'Sign Up'" backgroundColor="green"/>
-    <Button :title="'Log In'" backgroundColor="blue"/>
+    <div v-if="!accountCreated && !resetSuccess">
+      <h1>Track Progress</h1>
+      <p>Enter your email to track your progress and be rewarded!</p>
+      <input class="first" :class="{'valid': validEmail}" type="text" name="email" id="email" placeholder="ILove@DenStartupWeek.com" v-model="email" >
+      <input :class="{'valid': validPassword}" type="password" name="password" id="password" placeholder="Password" v-model="password" >
+      <p>Email will ONLY be used as login and to inform you if you've won</p>
+      <IntroStepCounter :numberOfSteps="numberOfSteps" :step="stepNumber" />
+      <div @click="signUp()">
+        <Button title="Sign Up" backgroundColor="green"/>
+      </div>
+      <span v-if="showError" class="form-error">Please correct form errors</span>
+      <div @click="logIn()">
+        <Button title="Log In" backgroundColor="blue"/>
+      </div>
+      <p @click="forgotPassword()">Forgot Password?</p>
+      <p v-if="resetPasswordWarning">Please provide valid email address</p>
+    </div>
+    <div v-if="accountCreated">
+      <h1>Account Created!</h1>
+      <p>Please check your email to verify your account</p>
+    </div>
+    <div v-if="resetSuccess">
+      <h1>Password Reset</h1>
+      <p>Please check your email to create a new password</p>
+    </div>
   </div>
 </template>
 
@@ -22,6 +38,7 @@ import Component from 'vue-class-component';
 
 import IntroStepCounter from '@/components/intro-step-counter/intro-step-counter-component.vue';
 import Button from '@/components/button/button-component.vue';
+import { Watch } from 'vue-property-decorator';
 
 @Component({
   props: {
@@ -36,12 +53,64 @@ import Button from '@/components/button/button-component.vue';
 export default class EnterEmailComponent extends Vue {
   public email = '';
   public password = '';
-  public placeholder = 'ILove@DenStartupWeek.com';
+  public showError = false;
+  public accountCreated = false;
+  public resetPasswordWarning = false;
+  public resetSuccess = false;
+  public $auth: any;
 
-  // API CALL
-  // Creates a user, or returns user data if user already exists
+  public async logIn() {
+    if (!this.formValid) {
+      this.showError = true;
+      return;
+    }
 
-  // TODO: Need to create a submit function...
+    this.$auth.logIn({
+      email_address: this.email,
+      password: this.password,
+    });
+  }
+
+  public async signUp() {
+    if (!this.formValid) {
+      this.showError = true;
+      return;
+    }
+
+    const result = this.$auth.signUp({
+      email_address: this.email,
+      password: this.password,
+    });
+
+    if (result) {
+      this.accountCreated = true;
+    }
+  }
+
+  public async forgotPassword() {
+    if (!this.validEmail) {
+      this.resetPasswordWarning = true;
+      return;
+    }
+
+    const result = this.$auth.recovery({
+      email_address: this.email,
+    });
+
+    if (result) {
+      this.resetSuccess = true;
+    }
+  }
+
+  @Watch('email')
+  public onEmailChange(email: string) {
+    this.showError = false;
+  }
+
+  @Watch('password')
+  public onPasswordChange(password: string) {
+    this.showError = false;
+  }
 
   get validEmail() {
     // Super simple email validation
@@ -52,6 +121,10 @@ export default class EnterEmailComponent extends Vue {
 
   get validPassword() {
     return this.password.length > 6;
+  }
+
+  get formValid() {
+    return this.validEmail && this.validPassword;
   }
 }
 </script>

--- a/src/components/onboarding/share-location/share-location-component.vue
+++ b/src/components/onboarding/share-location/share-location-component.vue
@@ -8,7 +8,7 @@
       <img src="../../../images/visited.svg" alt="location icon">
     </div>
     <h1>Share your location</h1>
-    <p>Requires Copy!!!!!!!!!!</p>
+    <p>When prompted, please allow this app access to your location so we can check you in when you arrive at each startup</p>
     <IntroStepCounter :numberOfSteps="numberOfSteps" :step="stepNumber" />
   </div>
 </template>

--- a/src/components/progress-banner/progress-banner-component.vue
+++ b/src/components/progress-banner/progress-banner-component.vue
@@ -24,17 +24,18 @@ import Component from 'vue-class-component';
 import { VenuesService } from '@/services/venue-service';
 import { Venue } from '@/models/venue-model';
 
-@Component({})
+@Component({
+  props: {
+    allVenues: Array,
+  },
+})
 export default class ProgressBannerComponent extends Vue {
   public venuesService = new VenuesService();
   public visitedVenues = this.venuesService.visitedVenues;
-  public allVenues: Venue[] = [];
-  public barsArray: boolean[] = [];
+  public allVenues: Venue[] = this.allVenues;
 
-  public async mounted() {
-    this.allVenues = await this.venuesService.getAllVenues();
-
-    this.barsArray = this.allVenues.map((venue, index) => {
+  public get barsArray() {
+    return this.allVenues.map((venue, index) => {
       return index < this.visitedVenues.length;
     });
   }

--- a/src/components/progress-banner/progress-banner-component.vue
+++ b/src/components/progress-banner/progress-banner-component.vue
@@ -32,7 +32,7 @@ import { Venue } from '@/models/venue-model';
 export default class ProgressBannerComponent extends Vue {
   public venuesService = new VenuesService();
   public visitedVenues = this.venuesService.visitedVenues;
-  public allVenues: Venue[] = this.allVenues;
+  public allVenues!: Venue[];
 
   public get barsArray() {
     return this.allVenues.map((venue, index) => {

--- a/src/components/venue-list/venue-list-component.vue
+++ b/src/components/venue-list/venue-list-component.vue
@@ -5,7 +5,7 @@
 <template>
   <div class="venue-list">
     <ul>
-      <li v-for="(venue, index) in venues" :key="index">
+      <li v-for="(venue, index) in allVenues" :key="index">
         <VenueListItem :venue="venue" :index="index" />
       </li>
     </ul>
@@ -17,20 +17,13 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 import VenueListItem from '@/components/venue-list/venue-list-item/venue-list-item-component.vue';
 
-import { VenuesService } from '../../services/venue-service';
-import { Venue } from '@/models/venue-model';
-
 @Component({
   components: {
     VenueListItem,
   },
+  props: {
+    allVenues: Array,
+  },
 })
-export default class VenueListComponent extends Vue {
-  public venueSevice: VenuesService = new VenuesService();
-  public venues: Venue[] = [];
-
-  public async mounted() {
-    this.venues = await this.venueSevice.getAllVenues();
-  }
-}
+export default class VenueListComponent extends Vue {}
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,14 @@ dotenv.config({debug: true});
 import Vue from 'vue';
 import App from './app.vue';
 import router from './router';
+import AuthPlugin from '@/plugins/auth';
 
 Vue.config.productionTip = false;
 
 // Set page title (Vue overrides html title tag)
 document.title = 'Stumbl | Denver Startup Week';
+
+Vue.use(AuthPlugin);
 
 new Vue({
   router,

--- a/src/models/user-model.ts
+++ b/src/models/user-model.ts
@@ -1,7 +1,7 @@
 export interface User {
   id: number;
   created_at: string;
-  email: string;
+  email_address: string;
   password: string;
   visited_venues: number[];
 }

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -1,0 +1,21 @@
+import authService from '@/services/auth-service';
+
+export default {
+  install(Vue) {
+    Vue.prototype.$auth = authService;
+
+    Vue.mixin({
+      created() {
+        if (this.handleLoginEvent) {
+          authService.addListener('login', this.handleLoginEvent)
+        }
+      },
+
+      destroyed() {
+        if (this.handleLoginEvent) {
+          authService.removeListener('login', this.handleLoginEvent)
+        }
+      },
+    })
+  },
+}

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -1,21 +1,21 @@
 import authService from '@/services/auth-service';
 
 export default {
-  install(Vue) {
+  install(Vue: any) {
     Vue.prototype.$auth = authService;
 
     Vue.mixin({
       created() {
         if (this.handleLoginEvent) {
-          authService.addListener('login', this.handleLoginEvent)
+          authService.addListener('login', this.handleLoginEvent);
         }
       },
 
       destroyed() {
         if (this.handleLoginEvent) {
-          authService.removeListener('login', this.handleLoginEvent)
+          authService.removeListener('login', this.handleLoginEvent);
         }
       },
-    })
+    });
   },
-}
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,11 +8,12 @@ const VenueDetails = () => import('./views/venue-details/venue-details.vue');
 const Intro = () => import('./views/intro/intro.vue');
 const PrizeEarned = () => import('./views/prize-earned/prize-earned.vue');
 const VenueDiscovered = () => import('./views/venue-discovered/venue-discovered.vue');
+const Confirmation = () => import('@/views/confirmation/confirmation.vue');
+const Recovery = () => import('@/views/recovery/recovery.vue');
 
 Vue.use(Router);
 
-
-export default new Router({
+const router = new Router({
   routes: [
     {
       path: '/',
@@ -50,9 +51,35 @@ export default new Router({
       component: VenueDiscovered,
     },
     {
+      path: '/confirmation/:confirmationId',
+      name: 'confirmation',
+      component: Confirmation,
+      props: true,
+    },
+    {
+      path: '/recovery/:recoveryId',
+      name: 'recovery',
+      component: Recovery,
+      props: true,
+    },
+    {
       path: '*',
       name: 'other',
       redirect: '/',
     },
   ],
 });
+
+// Sets up protected routes
+router.beforeEach((to, from, next) => {
+  if (router.app.$auth.isAuthenticated() ||
+    to.name === 'confirmation' ||
+    to.name === 'recovery' ||
+    to.name === 'intro') {
+    next();
+  } else {
+    next({ name: 'intro' });
+  }
+});
+
+export default router;

--- a/src/router.ts
+++ b/src/router.ts
@@ -72,7 +72,7 @@ const router = new Router({
 
 // Sets up protected routes
 router.beforeEach((to, from, next) => {
-  if (router.app.$auth.isAuthenticated() ||
+  if ((router.app as any).$auth.isAuthenticated() ||
     to.name === 'confirmation' ||
     to.name === 'recovery' ||
     to.name === 'intro') {

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -37,20 +37,32 @@ export default class ApiService {
   }
 
   /**
+   * Log in
+   */
+  public login = async (body) => {
+    
+  }
+
+  /**
    * Gets array of venues and their detail
    */
   public getAllVenues = async (): Promise<Venue[]> => {
     const hasCachedVenues = this.venues.length;
 
     if (hasCachedVenues) {
-      return await this.getCachedVenues();
+      return this.getCachedVenues();
     } else {
       try {
         // TODO: Connect this to API route
         const response = await fetch(`${API_URI}/events/${EVENT_ID}/locations`);
 
         const json = await response.json();
-        const data = json.data.map((entry: any) => entry.attributes) as Venue[];
+        const data = json.data.map((entry: any) => {
+          return {
+            id: entry.id,
+            ...entry.attributes,
+          };
+        }) as Venue[];
 
         this.venues = data;
 

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -4,7 +4,7 @@ import { User } from '@/models/user-model';
 const defaultUser = {
   id: 0,
   created_at: '',
-  email: '',
+  email_address: '',
   name: '',
   password: '',
   visited_venues: [],
@@ -34,13 +34,6 @@ export default class ApiService {
       this.user = { ...data };
       return this.user;
     }
-  }
-
-  /**
-   * Log in
-   */
-  public login = async (body) => {
-    
   }
 
   /**

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,0 +1,188 @@
+import EventEmitter from 'events';
+
+const API_URI = process.env.VUE_APP_STMBL_API_URI;
+const LOGGED_IN = 'dsw_logged_in';
+const TOKEN = 'dsw_user_token';
+const EXPIRES_AT = 'dsw_expires_at';
+
+interface Credentials {
+  email_address: string;
+  password: string;
+}
+
+interface ConfirmationCreds {
+  confirmation_id: string;
+  password: string;
+  password_confirmation: string;
+}
+
+interface Email {
+  email_address: string;
+}
+
+interface RecoveryCreds {
+  recovery_id: string;
+  password: string;
+  password_confirmation: string;
+}
+
+class AuthService extends EventEmitter {
+  /**
+   * Log in
+   */
+  public logIn = async (creds: Credentials) => {
+    const payload = {
+      data: {
+        attributes: {
+          ...creds,
+        },
+      },
+    };
+    await fetch(API_URI + '/authentications', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json())
+      .then((res) => {
+        this.localLogin(res);
+      })
+      .catch((error) => {
+        // console.log(error);
+      });
+  }
+
+  /**
+   * Sign Up
+   */
+  public signUp = async (creds: Credentials) => {
+    const payload = {
+      data: {
+        attributes: {
+          ...creds,
+        },
+      },
+    };
+    await fetch(API_URI + '/accounts', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json())
+    .then((res: any) => {
+      if (res.ok) {
+        return true;
+      } else {
+        return false;
+      }
+    }).catch((error) => {
+      // console.log(error);
+    });
+  }
+
+  /**
+   * Confirm Account
+   */
+  public confirmation = async (creds: ConfirmationCreds) => {
+    const { password, password_confirmation } = creds;
+    const passwords = { password, password_confirmation };
+    const payload = {
+      data: {
+        attributes: {
+          ...passwords,
+        },
+      },
+    };
+    fetch(API_URI + '/confirmations/' + creds.confirmation_id, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json())
+    .then((res: any) => {
+      this.localLogin(res);
+    }).catch((error) => {
+      // console.log(error);
+    });
+  }
+
+  /**
+   * Reset Password
+   */
+  public recovery = async (creds: Email) => {
+    const payload = {
+      data: {
+        attributes: {
+          ...creds,
+        },
+      },
+    };
+    fetch(API_URI + '/recoveries', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json())
+      .then((res) => {
+        return res.ok ? true : false;
+      });
+  }
+
+  /**
+   * Reset Account Password
+   */
+  public reset = async (creds: RecoveryCreds) => {
+    const { password, password_confirmation } = creds;
+    const passwords = { password, password_confirmation };
+    const payload = {
+      data: {
+        attributes: {
+          ...passwords,
+        },
+      },
+    };
+    fetch(API_URI + '/recoveries/' + creds.recovery_id, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json())
+    .then((res: any) => {
+      this.localLogin(res);
+    }).catch((error) => {
+      // console.log(error);
+    });
+  }
+
+  public isAuthenticated = () => {
+    const exp = localStorage.getItem(EXPIRES_AT);
+    const now = new Date().getTime() / 1000;
+    const loggedIn = localStorage.getItem(LOGGED_IN);
+
+    return parseInt(exp, 10) > now && loggedIn ? true : false;
+  }
+
+  /**
+   * Local login - sets token in localStorage and emits event to app
+   */
+  private localLogin = async (res: any) => {
+    const expires = Math.floor(new Date(res.data.attributes.expires_at).getTime() / 1000);
+
+    localStorage.setItem(LOGGED_IN, 'true');
+    localStorage.setItem(TOKEN, res.data.attributes.token);
+    localStorage.setItem(EXPIRES_AT, expires.toString());
+
+    this.emit('login');
+  }
+
+  private loginError = () => {
+    this.emit('loginError', 'Something went wrong. Please try again.');
+  }
+}
+
+export default new AuthService();

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -160,7 +160,7 @@ class AuthService extends EventEmitter {
   }
 
   public isAuthenticated = () => {
-    const exp = localStorage.getItem(EXPIRES_AT);
+    const exp = localStorage.getItem(EXPIRES_AT) || '';
     const now = new Date().getTime() / 1000;
     const loggedIn = localStorage.getItem(LOGGED_IN);
 

--- a/src/services/venue-service.ts
+++ b/src/services/venue-service.ts
@@ -49,12 +49,11 @@ export class VenuesService {
     return DEFAULT_VENUE;
   }
 
-  public getAllVenuesAsGeoJSON = async (): Promise<{type: string; features: GeoJsonVenue[]}> => {
-    const unformattedVenues = await this.getAllVenues();
+  public getAllVenuesAsGeoJSON = async (allVenues): Promise<{type: string; features: GeoJsonVenue[]}> => {
     const features: GeoJsonVenue[] = [];
 
-    if (unformattedVenues.length) {
-      unformattedVenues.forEach((venue: Venue) => {
+    if (allVenues.length) {
+      allVenues.forEach((venue: Venue) => {
         const formattedVenue = {
           id: venue.id!,
           geojson: {

--- a/src/services/venue-service.ts
+++ b/src/services/venue-service.ts
@@ -49,7 +49,7 @@ export class VenuesService {
     return DEFAULT_VENUE;
   }
 
-  public getAllVenuesAsGeoJSON = async (allVenues): Promise<{type: string; features: GeoJsonVenue[]}> => {
+  public getAllVenuesAsGeoJSON = async (allVenues: Venue[]): Promise<{type: string; features: GeoJsonVenue[]}> => {
     const features: GeoJsonVenue[] = [];
 
     if (allVenues.length) {

--- a/src/views/confirmation/confirmation.scss
+++ b/src/views/confirmation/confirmation.scss
@@ -1,0 +1,54 @@
+.confirmation {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh);
+  text-align: center;
+
+  &-logo {
+    padding: 15px;
+    display: flex;
+    justify-content: center;
+
+    img {
+      height: 72px;
+      width: auto;
+    }
+  }
+
+  &-mountains img {
+    width: 100%;
+    height: auto;
+  }
+
+  &-content {
+    flex-grow: 1;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  input {
+    box-sizing: border-box;
+    padding: 10px;
+    text-align: center;
+    width: 100%;
+    border: none;
+    border-radius: 4px;
+    font-size: 18px;
+    border-bottom: 3px solid red;
+
+    &:focus {
+      outline: none;
+    }
+
+    &.valid {
+      border-bottom: 3px solid $color_button-green;
+      color: green;
+    }
+
+    &.first {
+      margin-bottom: 10px;
+    }
+  }
+}

--- a/src/views/confirmation/confirmation.vue
+++ b/src/views/confirmation/confirmation.vue
@@ -1,0 +1,81 @@
+<style lang="scss" scoped>
+@import './confirmation.scss';
+</style>
+
+<template>
+  <div class="confirmation">
+      <div class="intro-logo">
+        <img src="../../images/dsw_logo.svg" alt="denver startup week logo">
+      </div>
+      <div class="confirmation-content">
+        <h1>Confirm Account</h1>
+        <p>Please enter and confirm and your password to start Stumblin'!</p>
+        <input class="first" :class="{'valid': validPassword}" type="password" name="password" id="password" placeholder="Password" v-model="password" >
+        <input :class="{'valid': validConfirm}" type="password" name="password_confirmation" id="password_confirmation" placeholder="Password Confirmation" v-model="passwordConfirmation" >
+        <button @click="submit()">
+          <Button title="Confirm" backgroundColor="green"/>
+        </button>
+      </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import router from '@/router';
+
+import Button from '@/components/button/button-component.vue';
+import { Watch } from 'vue-property-decorator';
+
+@Component({
+  components: {
+    Button,
+  },
+  props: {
+    confirmationId: String,
+  },
+})
+export default class Confirmation extends Vue {
+  public password = '';
+  public passwordConfirmation = '';
+  public showError = false;
+  public confirmationId!: string;
+  public $auth: any;
+
+  @Watch('password')
+  public onPasswordChange(password: string) {
+    this.showError = false;
+  }
+
+  @Watch('passwordConfirm')
+  public onPasswordConfirmationChange(passwordConfirmation: string) {
+    this.showError = false;
+  }
+
+  public async submit() {
+    if (!this.formError) {
+      this.showError = true;
+      return;
+    }
+
+    this.$auth.confirmation({
+      confirmation_id: this.confirmationId,
+      password: this.password,
+      password_confirmation: this.passwordConfirmation,
+    });
+  }
+
+  get validPassword() {
+    return this.password.length > 6;
+  }
+
+  get validConfirm() {
+    return this.password === this.passwordConfirmation && this.password !== '';
+  }
+
+  get formError() {
+    return this.validConfirm && this.validPassword;
+  }
+}
+</script>
+

--- a/src/views/home/home.vue
+++ b/src/views/home/home.vue
@@ -110,13 +110,13 @@ export default class Home extends Vue {
     this.polling = setInterval(() => {
       // retrieve list of venues that have not been visited
       const venuesToCheck = this.allVenues.filter(
-        (n) => !this.venueSevice.visitedVenues.includes(n.id!),
+        (n: Venue) => !this.venueSevice.visitedVenues.includes(n.id!),
       );
 
       // tslint:disable-next-line:no-console
       console.debug('Venues that haven\'t been visited', venuesToCheck);
 
-      venuesToCheck.forEach((venue, index) => {
+      venuesToCheck.forEach((venue: Venue, index: number) => {
         this.locationService
           .isWithinGeoRadius(
             200,

--- a/src/views/home/home.vue
+++ b/src/views/home/home.vue
@@ -2,7 +2,7 @@
   <div>
     <Header :showRewards="true" :showInfo="true" />
     <div class="home">
-      <Map />
+      <Map :all-venues="allVenues"/>
       <VenueListScroll>
         <Countdown />
         <AlertBanner
@@ -13,8 +13,8 @@
         >
           <a :href="locationPermissionLink" target="_blank">Share your location</a> to crawl!
         </AlertBanner>
-        <ProgressBanner />
-        <VenueList />
+        <ProgressBanner :all-venues="allVenues"/>
+        <VenueList :all-venues="allVenues"/>
       </VenueListScroll>
     </div>
   </div>
@@ -45,7 +45,12 @@ import { AlertTypeEnum } from '../../models/alert-model';
     VenueListScroll,
     ProgressBanner,
   },
+  props: {
+    allVenues: Array,
+  },
 })
+
+
 export default class Home extends Vue {
   public venueSevice = new VenuesService();
   public locationService = new LocationService();
@@ -53,6 +58,7 @@ export default class Home extends Vue {
   public locationPermissionActivated = false;
   public locationPermissionLink = '';
   public polling: any = null; // polling interval
+  public allVenues: any;
 
   public beforeMount() {
     // get position
@@ -100,11 +106,10 @@ export default class Home extends Vue {
 
   private async pollData() {
     const visitedVenues = this.venueSevice.visitedVenues;
-    const allVenues = await this.venueSevice.getAllVenues();
 
     this.polling = setInterval(() => {
       // retrieve list of venues that have not been visited
-      const venuesToCheck = allVenues.filter(
+      const venuesToCheck = this.allVenues.filter(
         (n) => !this.venueSevice.visitedVenues.includes(n.id!),
       );
 

--- a/src/views/intro/intro.vue
+++ b/src/views/intro/intro.vue
@@ -14,8 +14,8 @@
       <IntroWin v-if="introStep === 4" :numberOfSteps="totalSteps" :stepNumber="4"/>
       <EnterEmail v-if="introStep === 5" :numberOfSteps="totalSteps" :stepNumber="5"/>
     </div>
-    <div class="intro-next" v-on:click="nextStep()">
-      <Button :title="label" backgroundColor="blue"/>
+    <div class="intro-next" v-if="introStep !== totalSteps" v-on:click="nextStep()">
+      <Button :title="'Next'" backgroundColor="blue"/>
     </div>
     <div class="intro-mountains">
       <img src="../../images/mountains.svg" alt="mountain scenery">
@@ -45,28 +45,13 @@ import EnterEmail from '@/components/onboarding/email/enter-email-component.vue'
     IntroWin,
     EnterEmail,
   },
-  data() {
-    return {
-      buttonText: 'Next',
-    };
-  },
 })
 export default class Intro extends Vue {
   public introStep = 1;
   public totalSteps = 5;
 
-  get label() {
-    return this.introStep === 1 || this.introStep === this.totalSteps
-      ? 'Get Started'
-      : 'Next';
-  }
-
   public nextStep() {
-    this.$set(this.$data, 'buttonText', 'Next');
     this.introStep += 1;
-    if (this.introStep > this.totalSteps) {
-      router.push({ name: 'home', params: { authenticated: 'true' } });
-    }
   }
 }
 </script>

--- a/src/views/recovery/recovery.scss
+++ b/src/views/recovery/recovery.scss
@@ -1,0 +1,54 @@
+.recovery {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh);
+  text-align: center;
+
+  &-logo {
+    padding: 15px;
+    display: flex;
+    justify-content: center;
+
+    img {
+      height: 72px;
+      width: auto;
+    }
+  }
+
+  &-mountains img {
+    width: 100%;
+    height: auto;
+  }
+
+  &-content {
+    flex-grow: 1;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  input {
+    box-sizing: border-box;
+    padding: 10px;
+    text-align: center;
+    width: 100%;
+    border: none;
+    border-radius: 4px;
+    font-size: 18px;
+    border-bottom: 3px solid red;
+
+    &:focus {
+      outline: none;
+    }
+
+    &.first {
+      margin-bottom: 10px;
+    }
+
+    &.valid {
+      border-bottom: 3px solid $color_button-green;
+      color: green;
+    }
+  }
+}

--- a/src/views/recovery/recovery.vue
+++ b/src/views/recovery/recovery.vue
@@ -1,0 +1,81 @@
+<style lang="scss" scoped>
+@import './recovery.scss';
+</style>
+
+<template>
+  <div class="recovery">
+      <div class="intro-logo">
+        <img src="../../images/dsw_logo.svg" alt="denver startup week logo">
+      </div>
+      <div class="recovery-content">
+        <h1>Reset Password</h1>
+        <p>Please enter and confirm and your password to start Stumblin'!</p>
+        <input class="first" :class="{'valid': validPassword}" type="password" name="password" id="password" placeholder="Password" v-model="password" >
+        <input :class="{'valid': validConfirm}" type="password" name="password_confirmation" id="password_confirmation" placeholder="Password Confirmation" v-model="passwordConfirmation" >
+        <button @click="submit()">
+          <Button title="Confirm" backgroundColor="green"/>
+        </button>
+      </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import router from '@/router';
+
+import Button from '@/components/button/button-component.vue';
+import { Watch } from 'vue-property-decorator';
+
+@Component({
+  components: {
+    Button,
+  },
+  props: {
+    recoveryId: String,
+  },
+})
+export default class Reset extends Vue {
+  public password = '';
+  public passwordConfirmation = '';
+  public showError = false;
+  public recoveryId!: string;
+  public $auth: any;
+
+  @Watch('password')
+  public onPasswordChange(password: string) {
+    this.showError = false;
+  }
+
+  @Watch('passwordConfirm')
+  public onPasswordConfirmationChange(passwordConfirmation: string) {
+    this.showError = false;
+  }
+
+  public async submit() {
+    if (!this.formError) {
+      this.showError = true;
+      return;
+    }
+
+    this.$auth.reset({
+      recovery_id: this.recoveryId,
+      password: this.password,
+      password_confirmation: this.passwordConfirmation,
+    });
+  }
+
+  get validPassword() {
+    return this.password.length > 6;
+  }
+
+  get validConfirm() {
+    return this.password === this.passwordConfirmation && this.password !== '';
+  }
+
+  get formError() {
+    return this.validConfirm && this.validPassword;
+  }
+}
+</script>
+

--- a/src/views/rewards/rewards.vue
+++ b/src/views/rewards/rewards.vue
@@ -61,7 +61,7 @@ export default class Rewards extends Vue {
   public visitedVenues = this.venuesService.visitedVenues;
 
   public async mounted() {
-    this.email = await this.apiService.user.email;
+    this.email = await this.apiService.user.email_address;
   }
 }
 </script>

--- a/src/views/rewards/rewards.vue
+++ b/src/views/rewards/rewards.vue
@@ -8,7 +8,7 @@
     <div class="rewards">
       <h1 class="header-2">Your Rewards</h1>
       <p class="rewards-email">{{email}}</p>
-      <ProgressBannerComponent />
+      <ProgressBannerComponent :all-venues="allVenues"/>
       <RewardDetails
         title="Visit 1"
         subTitle="One entry to win"
@@ -27,7 +27,7 @@
       <RewardDetails
         title="Visited all"
         subTitle="Three entries to win"
-        :unLocked="this.visitedVenues.length === this.allVenues.length ? true : false"
+        :unLocked="this.visitedVenues.length === allVenues.length ? true : false"
       />
     </div>
   </div>
@@ -50,17 +50,18 @@ import ApiService from '@/services/api-service';
     ProgressBannerComponent,
     RewardDetails,
   },
+  props: {
+    allVenues: Array,
+  },
 })
 export default class Rewards extends Vue {
   public venuesService = new VenuesService();
   public apiService = new ApiService();
   public email: string = '';
   public visitedVenues = this.venuesService.visitedVenues;
-  public allVenues: Venue[] = [];
 
   public async mounted() {
     this.email = await this.apiService.user.email;
-    this.allVenues = await this.venuesService.getAllVenues();
   }
 }
 </script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     "src/**/*.tsx",
     "src/**/*.vue",
     "tests/**/*.ts",
-    "tests/**/*.tsx", "src/plugins/auth.js"
+    "tests/**/*.tsx", "src/plugins/auth.ts"
   ],
   "exclude": [
     "node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     "src/**/*.tsx",
     "src/**/*.vue",
     "tests/**/*.ts",
-    "tests/**/*.tsx"
+    "tests/**/*.tsx", "src/plugins/auth.js"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Description

- optimized the api service call to `getAllVenues`. It now occurs once in the App.vue on mount and passed as props to subsequent screen that need the venues. This reduced the calls to the api `/locations` from 4 to 1

- Create auth services with needed api requests. Created Vue mixin to call this globally
- Added validation and error states for all forms
- New views added for the password confirmation & password reset
- added protected routes middleware in router so only the intro, password reset, and account confirmation screen are accessible without being logged in
- 

**NOTE:** There are 3 TS errors in the build that I am not 100% sure on how to clean up and could use a hand on them
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
