### PR TITLE
FEAT: add private logic for admin page, lint errors

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -85,16 +85,9 @@ const router = new Router({
 
 // Sets up protected routes
 router.beforeEach((to, from, next) => {
-  if ((router.app as any).$auth.isAuthenticated() ||
-    to.name === 'intro' || to.name === 'recovery' || to.name === 'confirmation') {
-    next();
-  } else {
-    next({ name: 'intro' });
-  }
-
   if ((router.app as any).$auth.isAuthenticated() && to.name === 'admin-portal') {
     apiService.getUserData().then((result) => {
-      const venueId = to.params.venueId;
+      const { venueId}  = to.params;
 
       if (result.managed_locations.includes(venueId) || result.access.includes('admin')) {
         next();
@@ -102,7 +95,13 @@ router.beforeEach((to, from, next) => {
         next({ name: 'home' });
       }
     });
+  } else if ((router.app as any).$auth.isAuthenticated() ||
+    to.name === 'intro' || to.name === 'recovery' || to.name === 'confirmation') {
+    next();
+  } else {
+    next({ name: 'intro' });
   }
+
 });
 
 export default router;

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Router from 'vue-router';
+import ApiService from '@/services/api-service';
 
 const Home = () => import('@/views/home/home.vue');
 const About = () => import('@/views/about/about.vue');
@@ -11,6 +12,8 @@ const VenueDiscovered = () => import('@/views/venue-discovered/venue-discovered.
 const Confirmation = () => import('@/views/confirmation/confirmation.vue');
 const Recovery = () => import('@/views/recovery/recovery.vue');
 const AdminPortal = () => import('./views/admin-portal/admin-portal.vue');
+
+const apiService = new ApiService();
 
 Vue.use(Router);
 
@@ -87,6 +90,18 @@ router.beforeEach((to, from, next) => {
     next();
   } else {
     next({ name: 'intro' });
+  }
+
+  if ((router.app as any).$auth.isAuthenticated() && to.name === 'admin-portal') {
+    apiService.getUserData().then((result) => {
+      const venueId = to.params.venueId;
+
+      if (result.managed_locations.includes(venueId) || result.access.includes('admin')) {
+        next();
+      } else {
+        next({ name: 'home' });
+      }
+    });
   }
 });
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -54,7 +54,7 @@ class AuthService extends EventEmitter {
       })
       .then((res) => res.json())
       .then((res) => {
-        this.localLogin(res)
+        this.localLogin(res);
       })
       .catch((error) => {
         // console.log(error);

--- a/src/views/admin-portal/admin-portal.scss
+++ b/src/views/admin-portal/admin-portal.scss
@@ -31,7 +31,7 @@
 
   &__button {
     text-transform: uppercase;
-    margin: 16px 0;
+    margin: 16px auto;
   }
 
   &__textarea {
@@ -70,11 +70,11 @@
 
     &-label {
     // Button
-    width: 100%;
+    width: 90%;
     background: #05D3D8; // fallback
     background: $color_blue-gradient;
     border-radius: 4px;
-    margin-top: 10px;
+    margin: 10px auto 16px auto;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/views/admin-portal/admin-portal.vue
+++ b/src/views/admin-portal/admin-portal.vue
@@ -211,7 +211,8 @@ export default class AdminPortal extends Vue {
         this.venue = response.data.attributes;
       } else {
         this.bannerActive = true;
-        this.bannerMessage = 'Error saving.  You might not have permission to edit this venue.';
+        this.bannerMessage =
+          'Error saving.  You might not have permission to edit this venue.';
         this.bannerColor = 'red';
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds route protection for the admin route by checking if the user is an admin or if the user has managed locations and the current venue is part of those locations. This is done by making a call to the api-service and hits the `/me` endpoint to do so. 
- Fixes lint errors
- Adds some breathing room between the text area and `select new image` button. 
- Fixes margin overriding issue with buttons on the admin page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
