### PR TITLE
Refresh venue detail after admin updates venue

### DIFF
--- a/src/models/venue-model.ts
+++ b/src/models/venue-model.ts
@@ -5,7 +5,7 @@ export interface Venue {
   address_2: string;
   city: string;
   state: string;
-  zip_code: string;
+  zip: string;
   crawl_day: number; // 2 day event, could be either day (not both)
   latitude: string;
   longitude: string;

--- a/src/views/admin-portal/admin-portal.vue
+++ b/src/views/admin-portal/admin-portal.vue
@@ -14,9 +14,9 @@
     <Header></Header>
     <div class="portal">
       <h2 class="header-2">Startup crawl company admin</h2>
-      <router-link class="portal__page-link" :to="{name: 'venue', params: {venueId}}">
+      <a class="portal__page-link" :href="'/venue/' + venueId">
         <span class="portal__page-link">View Your Company Page</span>
-      </router-link>
+      </a>
       <p>Edit your company details below. This will be visible to crawl participants when they check in to your location.</p>
       <label class="portal__label">
         Company name

--- a/src/views/admin-portal/admin-portal.vue
+++ b/src/views/admin-portal/admin-portal.vue
@@ -237,7 +237,6 @@ export default class AdminPortal extends Vue {
     } else {
       const response = await this.apiService.updateVenue(this.venue);
       if (response.data) {
-        console.log('DATA', response)
         this.bannerActive = true;
         this.venue = {
           id: response.data.id,

--- a/src/views/admin-portal/admin-portal.vue
+++ b/src/views/admin-portal/admin-portal.vue
@@ -51,6 +51,36 @@
         />
       </label>
       <label class="portal__label">
+        City
+        <input
+          type="text"
+          class="portal__input"
+          name="city"
+          placeholder="City"
+          v-model="venue.city"
+        />
+      </label>
+      <label class="portal__label">
+        State
+        <input
+          type="text"
+          class="portal__input"
+          name="state"
+          placeholder="State"
+          v-model="venue.state"
+        />
+      </label>
+      <label class="portal__label">
+        Zip Code
+        <input
+          type="text"
+          class="portal__input"
+          name="zip"
+          placeholder="Zip Code"
+          v-model="venue.zip"
+        />
+      </label>
+      <label class="portal__label">
         Website
         <input
           type="text"
@@ -207,6 +237,7 @@ export default class AdminPortal extends Vue {
     } else {
       const response = await this.apiService.updateVenue(this.venue);
       if (response.data) {
+        console.log('DATA', response)
         this.bannerActive = true;
         this.venue = {
           id: response.data.id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
AllVenues state wasn't updating when saving venue edit.  Quick and dirty fix -- refresh when they navigate away

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
