### PR TITLE
fix(style): center elements in "more about skookum" button

### DIFF
--- a/src/views/about/about.scss
+++ b/src/views/about/about.scss
@@ -3,6 +3,14 @@
   font-size: 16px;
   padding: $global-padding;
 
+  &__more-button {
+    justify-content: center;
+
+    & p {
+      margin-left: 16px;
+    }
+  }
+
   & ul {
     list-style: none;
 

--- a/src/views/about/about.vue
+++ b/src/views/about/about.vue
@@ -34,6 +34,7 @@
         </p>
       </div>
       <Button
+        class="about__more-button"
         title="More about skookum"
         :showImage="true"
         backgroundColor="white"

--- a/src/views/home/home.vue
+++ b/src/views/home/home.vue
@@ -173,7 +173,9 @@ export default class Home extends Vue {
       this.displayDayTwo = true;
     }
 
-    this.displayAll = true;
+    if (!this.isDayOne && !this.isDayTwo) {
+      this.displayAll = true;
+    }
   }
 
   get isDayOne() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
the "Learn more" button elements were justified `space-evenly` which looked crazy on larger screen.

This changes them to `center` with a little margin on the `p` element.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):
Before:

![Screen Shot 2019-09-17 at 9 22 54 AM](https://user-images.githubusercontent.com/815350/65055719-ef69fd80-d92c-11e9-8877-753febac4d4d.png)

After:

![Screen Shot 2019-09-17 at 9 23 03 AM](https://user-images.githubusercontent.com/815350/65055737-f55fde80-d92c-11e9-9582-6a0bc457f185.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
