### PR TITLE
fix: admin portal buttons only show up for admins

### DIFF
--- a/src/views/venue-details/venue-details.vue
+++ b/src/views/venue-details/venue-details.vue
@@ -81,14 +81,11 @@ export default class VenueDetails extends Vue {
   }
 
   get isVenueAdmin() {
-    const isRootAdmin = localStorage.getItem(ROOT_ADMIN) || false;
+    const isRootAdmin = localStorage.getItem(ROOT_ADMIN) || 'false';
     const hasAdminVenues = localStorage.getItem(ADMIN_VENUES) || false;
     const parsedVenues = hasAdminVenues ? JSON.parse(hasAdminVenues) : [];
 
-    if (!!isRootAdmin || (hasAdminVenues && parsedVenues.includes(this.venueId))) {
-      return true;
-    }
-    return false;
+    return (JSON.parse(isRootAdmin) || parsedVenues.includes(this.venueId));
   }
 
   public openDirections(destination: string) {


### PR DESCRIPTION
`localStorage` will only store strings, never an actual Boolean. For this
reason, the `!!isRootAdmin` will always evalute to true as long as it is
assigned a string with a length. JSON.parse-ing the string value will actually
cast the string to a boolean value, which creates the desired effect.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
